### PR TITLE
Allow RowMajorMatrix to be empty

### DIFF
--- a/commit/src/mmcs.rs
+++ b/commit/src/mmcs.rs
@@ -22,7 +22,7 @@ use serde::Serialize;
 pub trait Mmcs<T>: Clone {
     type ProverData;
     type Commitment: Clone + Serialize + DeserializeOwned;
-    type Proof: Serialize + DeserializeOwned;
+    type Proof: Clone + Serialize + DeserializeOwned;
     type Error: Debug;
     type Mat<'a>: MatrixRows<T> + Sync
     where

--- a/commit/src/pcs.rs
+++ b/commit/src/pcs.rs
@@ -25,7 +25,7 @@ pub trait Pcs<Val: Field, In: MatrixRows<Val>> {
     type ProverData;
 
     /// The opening argument.
-    type Proof: Serialize + DeserializeOwned;
+    type Proof: Clone + Serialize + DeserializeOwned;
 
     type Error: Debug;
 

--- a/fri/src/proof.rs
+++ b/fri/src/proof.rs
@@ -4,7 +4,7 @@ use p3_commit::Mmcs;
 use p3_field::Field;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(bound(
     serialize = "Witness: Serialize",
     deserialize = "Witness: Deserialize<'de>"
@@ -18,7 +18,7 @@ pub struct FriProof<F: Field, M: Mmcs<F>, Witness> {
     pub(crate) pow_witness: Witness,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(bound = "")]
 pub struct QueryProof<F: Field, M: Mmcs<F>> {
     /// For each commit phase commitment, this contains openings of a commit phase codeword at the
@@ -26,7 +26,7 @@ pub struct QueryProof<F: Field, M: Mmcs<F>> {
     pub(crate) commit_phase_openings: Vec<CommitPhaseProofStep<F, M>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 // #[serde(bound(serialize = "F: Serialize"))]
 #[serde(bound = "")]
 pub struct CommitPhaseProofStep<F: Field, M: Mmcs<F>> {

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -99,7 +99,7 @@ impl<C: TwoAdicFriPcsGenericConfig> Debug for VerificationError<C> {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(bound = "")]
 pub struct TwoAdicFriPcsProof<C: TwoAdicFriPcsGenericConfig> {
     pub(crate) fri_proof: FriProof<C::Challenge, C::FriMmcs, C::Val>,
@@ -107,7 +107,7 @@ pub struct TwoAdicFriPcsProof<C: TwoAdicFriPcsGenericConfig> {
     pub(crate) query_openings: Vec<Vec<BatchOpening<C>>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct BatchOpening<C: TwoAdicFriPcsGenericConfig> {
     pub(crate) opened_values: Vec<Vec<C::Val>>,
     pub(crate) opening_proof: <C::InputMmcs as Mmcs<C::Val>>::Proof,

--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -24,8 +24,7 @@ pub struct RowMajorMatrix<T> {
 impl<T> RowMajorMatrix<T> {
     #[must_use]
     pub fn new(values: Vec<T>, width: usize) -> Self {
-        debug_assert!(width >= 1);
-        debug_assert_eq!(values.len() % width, 0);
+        debug_assert!(width == 0 || values.len() % width == 0);
         Self { values, width }
     }
 


### PR DESCRIPTION
This is Plonky3#327.

Allowing `RowMajorMatrix`'s to be empty makes it easier to work with potentially empty trace components (public, preprocessed, or main). 