### PR TITLE
allow RowMajorMatrix to be empty

### DIFF
--- a/matrix/src/dense.rs
+++ b/matrix/src/dense.rs
@@ -24,8 +24,7 @@ pub struct RowMajorMatrix<T> {
 impl<T> RowMajorMatrix<T> {
     #[must_use]
     pub fn new(values: Vec<T>, width: usize) -> Self {
-        debug_assert!(width >= 1);
-        debug_assert_eq!(values.len() % width, 0);
+        debug_assert!(width == 0 || values.len() % width == 0);
         Self { values, width }
     }
 
@@ -185,7 +184,11 @@ impl<T> Matrix<T> for RowMajorMatrix<T> {
     }
 
     fn height(&self) -> usize {
-        self.values.len() / self.width
+        if self.width == 0 {
+            0
+        } else {
+            self.values.len() / self.width
+        }
     }
 }
 


### PR DESCRIPTION
See also Plonky3#327. Allowing the width of a RowMajorMatrix to be 0 simplifies a number of annoying issues that arise when handling potentially empty trace components (i.e. the possibility that the preprocessed, public, or main trace for a particular chip is empty). 