### PR TITLE
Refactor `PublicValues` interface to be compatible with upstream

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 
 use itertools::{izip, Itertools};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::{Mmcs, OpenedValues, Pcs, PolynomialSpace};
+use p3_commit::{Mmcs, OpenedValues, Pcs, PcsValidaExt, PolynomialSpace};
 use p3_field::extension::ComplexExtendable;
 use p3_field::{ExtensionField, Field};
 use p3_fri::verifier::FriError;
@@ -468,6 +468,54 @@ where
                 Ok(fri_input)
             },
         )
+    }
+}
+
+impl<Val, Challenge, Challenger, InputMmcs, FriMmcs> PcsValidaExt<Challenge, Challenger>
+    for CirclePcs<Val, InputMmcs, FriMmcs>
+where
+    Val: ComplexExtendable,
+    Challenge: ExtensionField<Val>,
+    InputMmcs: Mmcs<Val>,
+    FriMmcs: Mmcs<Challenge>,
+    Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<FriMmcs::Commitment>,
+{
+    fn domain_extend_evaluations<'a>(
+        &self,
+        evaluations: RowMajorMatrix<p3_commit::Val<Self::Domain>>,
+        evaluation_domain: Self::Domain,
+        extension_domain: Self::Domain,
+    ) -> impl Matrix<Val> + 'a {
+        let evals = CircleEvaluations::from_natural_order(evaluation_domain, evaluations);
+
+        evals.extrapolate(extension_domain).to_cfft_order().as_cow()
+    }
+    fn evaluate_at_points<M>(
+        &self,
+        evaluations: &M,
+        evaluation_domain: Self::Domain,
+        points: &[Challenge],
+    ) -> Vec<Vec<Challenge>>
+    where
+        M: Matrix<Val> + Clone,
+    {
+        let evals = CircleEvaluations::from_natural_order(evaluation_domain, evaluations.clone());
+
+        points
+            .iter()
+            .map(|&zeta| {
+                let zeta = Point::from_projective_line(zeta);
+
+                // Staying in evaluation form, we lagrange interpolate to get the value of
+                // each p at zeta.
+                // todo: we only need half of the values to interpolate, but how?
+                let ps_at_zeta: Vec<Challenge> =
+                    info_span!("compute opened values with Lagrange interpolation")
+                        .in_scope(|| evals.evaluate_at_point(zeta));
+
+                ps_at_zeta
+            })
+            .collect()
     }
 }
 

--- a/commit/src/pcs_valida.rs
+++ b/commit/src/pcs_valida.rs
@@ -7,8 +7,10 @@
 //!
 //! In particular we need public non-bit-reversed LDEs.
 use alloc::vec::Vec;
+
 use p3_field::ExtensionField;
-use p3_matrix::{dense::RowMajorMatrix, Matrix};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::Matrix;
 
 use crate::pcs::{Pcs, Val};
 

--- a/commit/src/pcs_valida.rs
+++ b/commit/src/pcs_valida.rs
@@ -6,17 +6,38 @@
 //! valida-vm is compatible with latest Plonky3.
 //!
 //! In particular we need public non-bit-reversed LDEs.
+use alloc::vec::Vec;
 use p3_field::ExtensionField;
-use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::{dense::RowMajorMatrix, Matrix};
 
 use crate::pcs::{Pcs, Val};
 
 pub trait PcsValidaExt<Challenge, Challenger>: Pcs<Challenge, Challenger>
 where
-    Challenge: ExtensionField<Val<<Self as Pcs<Challenge, Challenger>>::Domain>>,
+    Challenge: ExtensionField<Val<Self::Domain>>,
 {
-    fn compute_lde_batch(
+    // Should be the same as
+    // ```
+    //    let(_commit, data) = self.commit(vec![evaluations]);
+    //    self.get_evaluations_on_domain(&data, 0, domain)
+    // ```
+    // but faster, without the need to compute the actual commitment
+    fn domain_extend_evaluations<'a>(
         &self,
-        polynomials: RowMajorMatrix<Val<<Self as Pcs<Challenge, Challenger>>::Domain>>,
-    ) -> RowMajorMatrix<Val<<Self as Pcs<Challenge, Challenger>>::Domain>>;
+        evaluations: RowMajorMatrix<Val<Self::Domain>>,
+        evaluation_domain: Self::Domain,
+        extension_domain: Self::Domain,
+    ) -> impl Matrix<Val<Self::Domain>> + 'a;
+
+    // For each point in `points`, return the evaluations
+    // of the polynomial encoded by each column of `evaluations`
+    // using `evaluation domain` at that point.
+    fn evaluate_at_points<M>(
+        &self,
+        evaluations: &M,
+        evaluation_domain: Self::Domain,
+        points: &[Challenge],
+    ) -> Vec<Vec<Challenge>>
+    where
+        M: Matrix<Val<Self::Domain>> + Clone;
 }

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -10,7 +10,7 @@ use p3_matrix::Matrix;
 use p3_util::log2_strict_usize;
 use serde::{Deserialize, Serialize};
 
-use crate::{OpenedValues, Pcs, PolynomialSpace, TwoAdicMultiplicativeCoset};
+use crate::{OpenedValues, Pcs, PcsValidaExt, PolynomialSpace, TwoAdicMultiplicativeCoset};
 
 /// A trivial PCS: its commitment is simply the coefficients of each poly.
 #[derive(Debug)]
@@ -168,5 +168,63 @@ where
             }
         }
         Ok(())
+    }
+}
+
+impl<Val, Dft, Challenge, Challenger> PcsValidaExt<Challenge, Challenger> for TrivialPcs<Val, Dft>
+where
+    Val: TwoAdicField,
+    Dft: TwoAdicSubgroupDft<Val>,
+    Challenge: ExtensionField<Val>,
+    Challenger: CanSample<Challenge>,
+{
+    fn domain_extend_evaluations<'a>(
+        &self,
+        evaluations: RowMajorMatrix<Val>,
+        evaluation_domain: Self::Domain,
+        extension_domain: Self::Domain,
+    ) -> impl Matrix<Val> + 'a {
+        assert!(evaluations.height() == evaluation_domain.size());
+        let mut coeffs = self.dft.idft_batch(evaluations);
+        coeffs
+            .rows_mut()
+            .zip(evaluation_domain.shift.inverse().powers())
+            .for_each(|(row, weight)| {
+                row.iter_mut().for_each(|coeff| {
+                    *coeff *= weight;
+                })
+            });
+        assert!(extension_domain.log_n >= evaluation_domain.log_n);
+        coeffs.values.resize(
+            coeffs.values.len() << (extension_domain.log_n - evaluation_domain.log_n),
+            Val::zero(),
+        );
+        self.dft.coset_dft_batch(coeffs, extension_domain.shift)
+    }
+
+    fn evaluate_at_points<M>(
+        &self,
+        evaluations: &M,
+        evaluation_domain: Self::Domain,
+        points: &[Challenge],
+    ) -> Vec<Vec<Challenge>>
+    where
+        M: Matrix<crate::Val<Self::Domain>> + Clone,
+    {
+        let mut coeffs = self
+            .dft
+            .idft_batch(evaluations.clone().to_row_major_matrix());
+        coeffs
+            .rows_mut()
+            .zip(evaluation_domain.shift.inverse().powers())
+            .for_each(|(row, weight)| {
+                row.iter_mut().for_each(|coeff| {
+                    *coeff *= weight;
+                })
+            });
+        points
+            .iter()
+            .map(|pt| eval_coeffs_at_pt(&coeffs, *pt))
+            .collect()
     }
 }

--- a/keccak-air/examples/prove_baby_bear_keccak.rs
+++ b/keccak-air/examples/prove_baby_bear_keccak.rs
@@ -8,7 +8,6 @@ use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_matrix::Matrix;
-use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_monty_31::dft::RecursiveDft;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
@@ -70,8 +69,20 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &PublicRow::<Val>::default());
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::<Val>::default(),
+    );
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &RowMajorMatrix::new(vec![], 0))
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/keccak-air/examples/prove_baby_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_baby_bear_poseidon2.rs
@@ -8,7 +8,6 @@ use p3_field::Field;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_matrix::Matrix;
-use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_monty_31::dft::RecursiveDft;
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
@@ -77,8 +76,20 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::new(perm.clone());
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &PublicRow::<Val>::default());
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::<Val>::default(),
+    );
 
     let mut challenger = Challenger::new(perm);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &RowMajorMatrix::new(vec![], 0))
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/keccak-air/examples/prove_baby_bear_sha256.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256.rs
@@ -10,7 +10,7 @@ use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_sha256::Sha256;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::random;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -68,8 +68,20 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::default(),
+    );
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/keccak-air/examples/prove_baby_bear_sha256_compress.rs
+++ b/keccak-air/examples/prove_baby_bear_sha256_compress.rs
@@ -10,7 +10,7 @@ use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_sha256::{Sha256, Sha256Compress};
 use p3_symmetric::SerializingHasher32;
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::random;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -68,8 +68,20 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::default(),
+    );
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/keccak-air/examples/prove_goldilocks_keccak.rs
+++ b/keccak-air/examples/prove_goldilocks_keccak.rs
@@ -8,7 +8,6 @@ use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_goldilocks::Goldilocks;
 use p3_keccak::Keccak256Hash;
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
-use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher64};
 use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
@@ -69,8 +68,20 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &PublicRow::<Val>::default());
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::<Val>::default(),
+    );
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &RowMajorMatrix::new(vec![], 0))
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::<Val>::default(),
+    )
 }

--- a/keccak-air/examples/prove_goldilocks_poseidon.rs
+++ b/keccak-air/examples/prove_goldilocks_poseidon.rs
@@ -11,7 +11,7 @@ use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_poseidon::Poseidon;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::{random, thread_rng};
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -71,8 +71,20 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::new(perm.clone());
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::default(),
+    );
 
     let mut challenger = Challenger::new(perm);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/keccak-air/examples/prove_goldilocks_sha256.rs
+++ b/keccak-air/examples/prove_goldilocks_sha256.rs
@@ -10,7 +10,7 @@ use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_sha256::Sha256;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher64};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::random;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -68,8 +68,20 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::default(),
+    );
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/keccak-air/examples/prove_koala_bear_poseidon2.rs
+++ b/keccak-air/examples/prove_koala_bear_poseidon2.rs
@@ -11,7 +11,7 @@ use p3_koala_bear::{DiffusionMatrixKoalaBear, KoalaBear};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::{random, thread_rng};
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -75,8 +75,20 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::new(perm.clone());
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::default(),
+    );
 
     let mut challenger = Challenger::new(perm);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/keccak-air/examples/prove_m31_keccak.rs
+++ b/keccak-air/examples/prove_m31_keccak.rs
@@ -11,7 +11,7 @@ use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_mersenne_31::Mersenne31;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::random;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -71,8 +71,20 @@ fn main() -> Result<(), impl Debug> {
     let trace = generate_trace_rows::<Val>(inputs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::default(),
+    );
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/keccak-air/examples/prove_m31_poseidon2.rs
+++ b/keccak-air/examples/prove_m31_poseidon2.rs
@@ -12,7 +12,7 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_mersenne_31::{DiffusionMatrixMersenne31, Mersenne31};
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::{random, thread_rng};
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -78,8 +78,20 @@ fn main() -> Result<(), impl Debug> {
     let trace = generate_trace_rows::<Val>(inputs);
 
     let mut challenger = Challenger::new(perm.clone());
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::default(),
+    );
 
     let mut challenger = Challenger::new(perm);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/keccak-air/examples/prove_m31_sha256.rs
+++ b/keccak-air/examples/prove_m31_sha256.rs
@@ -11,7 +11,7 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_mersenne_31::Mersenne31;
 use p3_sha256::Sha256;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::random;
 use tracing_forest::util::LevelFilter;
 use tracing_forest::ForestLayer;
@@ -71,8 +71,20 @@ fn main() -> Result<(), impl Debug> {
     let trace = generate_trace_rows::<Val>(inputs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &KeccakAir {}, &mut challenger, trace, &vec![]);
+    let proof = prove(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        trace,
+        PublicRow::default(),
+    );
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &KeccakAir {}, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &KeccakAir {},
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
@@ -117,7 +117,7 @@ fn main() -> Result<(), impl Debug> {
         VECTOR_LEN,
     > = VectorizedPoseidon2Air::new(constants, external_linear_layer, internal_linear_layer);
 
-    let dft = Dft {};
+    let dft = Dft::default();
 
     let fri_config = FriConfig {
         log_blowup: 1,

--- a/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_baby_bear_keccak.rs
@@ -11,7 +11,7 @@ use p3_monty_31::GenericDiffusionMatrixMontyField31;
 use p3_poseidon2::Poseidon2ExternalMatrixGeneral;
 use p3_poseidon2_air::{generate_vectorized_trace_rows, RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32To64};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::{random, thread_rng};
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
@@ -132,8 +132,14 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &air, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &air, &mut challenger, trace, PublicRow::default());
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &air, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &air,
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_keccak.rs
@@ -11,7 +11,7 @@ use p3_monty_31::GenericDiffusionMatrixMontyField31;
 use p3_poseidon2::Poseidon2ExternalMatrixGeneral;
 use p3_poseidon2_air::{generate_vectorized_trace_rows, RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32To64};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::{random, thread_rng};
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
@@ -132,8 +132,14 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &air, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &air, &mut challenger, trace, PublicRow::default());
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &air, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &air,
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/poseidon2-air/examples/prove_poseidon2_koala_bear_poseidon2.rs
+++ b/poseidon2-air/examples/prove_poseidon2_koala_bear_poseidon2.rs
@@ -14,7 +14,7 @@ use p3_monty_31::GenericDiffusionMatrixMontyField31;
 use p3_poseidon2::{Poseidon2, Poseidon2ExternalMatrixGeneral};
 use p3_poseidon2_air::{generate_trace_rows, Poseidon2Air, RoundConstants};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::{random, thread_rng};
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
@@ -123,8 +123,14 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::new(perm.clone());
-    let proof = prove(&config, &air, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &air, &mut challenger, trace, PublicRow::default());
 
     let mut challenger = Challenger::new(perm);
-    verify(&config, &air, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &air,
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/poseidon2-air/examples/prove_poseidon2_m31_keccak.rs
+++ b/poseidon2-air/examples/prove_poseidon2_m31_keccak.rs
@@ -12,7 +12,7 @@ use p3_mersenne_31::{GenericDiffusionMatrixMersenne31, Mersenne31};
 use p3_poseidon2::Poseidon2ExternalMatrixGeneral;
 use p3_poseidon2_air::{generate_vectorized_trace_rows, RoundConstants, VectorizedPoseidon2Air};
 use p3_symmetric::{CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher32To64};
-use p3_uni_stark::{prove, verify, StarkConfig};
+use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::{random, thread_rng};
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
@@ -129,8 +129,14 @@ fn main() -> Result<(), impl Debug> {
     let config = MyConfig::new(pcs);
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    let proof = prove(&config, &air, &mut challenger, trace, &vec![]);
+    let proof = prove(&config, &air, &mut challenger, trace, PublicRow::default());
 
     let mut challenger = Challenger::from_hasher(vec![], byte_hash);
-    verify(&config, &air, &mut challenger, &proof, &vec![])
+    verify(
+        &config,
+        &air,
+        &mut challenger,
+        &proof,
+        &PublicRow::default(),
+    )
 }

--- a/uni-stark/src/lib.rs
+++ b/uni-stark/src/lib.rs
@@ -1,6 +1,6 @@
 //! A minimal univariate STARK framework.
 
-#![no_std]
+//#![no_std]
 
 extern crate alloc;
 

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -5,6 +5,8 @@ use core::iter;
 use itertools::{izip, Itertools};
 use p3_air::Air;
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
+// LITA
+use p3_commit::PcsValidaExt;
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{AbstractExtensionField, AbstractField, PackedValue};
 use p3_matrix::dense::RowMajorMatrix;
@@ -12,9 +14,6 @@ use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_ceil_usize, log2_strict_usize};
 use tracing::{info_span, instrument};
-
-// LITA
-use p3_commit::PcsValidaExt;
 
 use crate::{
     get_symbolic_constraints, Commitments, Domain, OpenedValues, PackedChallenge, PackedVal, Proof,

--- a/uni-stark/src/public.rs
+++ b/uni-stark/src/public.rs
@@ -2,9 +2,8 @@ use alloc::slice;
 use alloc::vec::Vec;
 use core::iter;
 
-use p3_commit::{Pcs, PcsValidaExt, PolynomialSpace};
-use p3_field::{ExtensionField, Field, TwoAdicField};
-use p3_matrix::dense::RowMajorMatrix;
+use p3_commit::{PcsValidaExt, PolynomialSpace};
+use p3_field::{ExtensionField, Field};
 use p3_matrix::Matrix;
 pub trait PublicValues<F, E>: Matrix<F> + Sized + Clone
 where

--- a/uni-stark/src/public.rs
+++ b/uni-stark/src/public.rs
@@ -2,7 +2,7 @@ use alloc::slice;
 use alloc::vec::Vec;
 use core::iter;
 
-use p3_commit::PcsValidaExt;
+use p3_commit::{Pcs, PcsValidaExt, PolynomialSpace};
 use p3_field::{ExtensionField, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
@@ -29,7 +29,9 @@ where
 
     fn get_ldes<SC>(&self, config: &SC) -> Self
     where
-        SC: StarkGenericConfig<Challenge = E>;
+        SC: StarkGenericConfig<Challenge = E>,
+        <SC::Pcs as Pcs<SC::Challenge, SC::Challenger>>::Domain: PolynomialSpace<Val = F>,
+        <SC as StarkGenericConfig>::Pcs: PcsValidaExt<E, <SC as StarkGenericConfig>::Challenger>;
 }
 
 impl<F, E, T> PublicValues<F, E> for T
@@ -40,7 +42,8 @@ where
 {
     fn get_ldes<SC>(&self, config: &SC) -> Self
     where
-        SC: StarkGenericConfig<Challenge=E>,
+        SC: StarkGenericConfig<Challenge = E>,
+        <SC::Pcs as Pcs<SC::Challenge, SC::Challenger>>::Domain: PolynomialSpace<Val = F>,
         <SC as StarkGenericConfig>::Pcs: PcsValidaExt<E, <SC as StarkGenericConfig>::Challenger>,
     {
         let pcs = config.pcs();

--- a/uni-stark/src/symbolic_builder.rs
+++ b/uni-stark/src/symbolic_builder.rs
@@ -97,7 +97,8 @@ impl<F: Field> SymbolicAirBuilder<F> {
         let public_values = [0, 1]
             .into_iter()
             .flat_map(|offset| {
-                (0..num_public_values).map(move |index| SymbolicVariable::new(Entry::Main { offset }, index))
+                (0..num_public_values)
+                    .map(move |index| SymbolicVariable::new(Entry::Main { offset }, index))
             })
             .collect();
         Self {

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -3,14 +3,13 @@ use alloc::vec;
 use itertools::Itertools;
 use p3_air::{Air, BaseAir};
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
+// LITA
+use p3_commit::PcsValidaExt;
 use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{AbstractExtensionField, AbstractField, Field};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use tracing::instrument;
-
-// LITA
-use p3_commit::PcsValidaExt;
 
 use crate::symbolic_builder::{get_log_quotient_degree, SymbolicAirBuilder};
 use crate::{PcsError, Proof, PublicValues, StarkGenericConfig, Val, VerifierConstraintFolder};

--- a/uni-stark/tests/mul_air.rs
+++ b/uni-stark/tests/mul_air.rs
@@ -10,7 +10,7 @@ use p3_commit::testing::TrivialPcs;
 use p3_commit::{ExtensionMmcs, PcsValidaExt};
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{AbstractField, Field, TwoAdicField};
+use p3_field::{AbstractField, Field};
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
 use p3_matrix::dense::RowMajorMatrix;


### PR DESCRIPTION
This was particularly relevant to make the tests using circle STARKs / Mersenne31 to pass. I think using the `Domain` abstraction introduced upstream is also good in general. 

Note: it isn't particularly important to maintain `uni-stark` to use our changes, as long as it is compatible with our changes made elsewhere. The ability to use a `Matrix` for public instance variables is useful in Valida, but not really needed here. However, as `uni-stark` is a simplified template for Valida, maintaining this is a way to see how changes will affect Valida in a somewhat simpler context.