### PR TITLE
rebase morgan parallelization merge commits \n\n

### DIFF
--- a/dft/src/radix_2_bowers.rs
+++ b/dft/src/radix_2_bowers.rs
@@ -112,13 +112,13 @@ fn butterfly_layer<F: Field, B: Butterfly<F>>(
     half_block_size: usize,
     twiddles: &[B],
 ) {
-    mat.par_row_chunks_exact_mut(2 * half_block_size)
+    mat.par_row_chunks_exact_mut(2 * half_block_size) // LITA: check if worth it to unparallelize
         .enumerate()
         .for_each(|(block, mut chunks)| {
             let (mut hi_chunks, mut lo_chunks) = chunks.split_rows_mut(half_block_size);
             hi_chunks
-                .par_rows_mut()
-                .zip(lo_chunks.par_rows_mut())
+                .par_rows_mut() // LITA: check if worth it to unparallelize
+                .zip(lo_chunks.par_rows_mut()) // LITA: check if worth it to unparallelize
                 .for_each(|(hi_chunk, lo_chunk)| {
                     if block == 0 {
                         TwiddleFreeButterfly.apply_to_rows(hi_chunk, lo_chunk)

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -58,16 +58,15 @@ where
 
         let commit_phase_openings: Vec<_> = query_indices
             .into_par_iter()
-            .map(|index| answer_query(
-                config,
-                &commit_phase_result.data,
-                index >> extra_bits,
-            ))
+            .map(|index| answer_query(config, &commit_phase_result.data, index >> extra_bits))
             .collect();
 
         // LITA TODO: Support rayon multizip with a shim for non-parallel
         izip!(input_proofs, commit_phase_openings)
-            .map(|(input_proof, commit_phase_openings)| QueryProof {input_proof, commit_phase_openings})
+            .map(|(input_proof, commit_phase_openings)| QueryProof {
+                input_proof,
+                commit_phase_openings,
+            })
             .collect()
     });
 

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -1,12 +1,12 @@
 use alloc::vec;
 use alloc::vec::Vec;
-use core::iter;
 
 use itertools::{izip, Itertools};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field};
-use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
+use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 use tracing::{info_span, instrument};
 
@@ -23,7 +23,9 @@ pub fn prove<G, Val, Challenge, M, Challenger>(
 where
     Val: Field,
     Challenge: ExtensionField<Val>,
-    M: Mmcs<Challenge>,
+    M: Mmcs<Challenge> + Sync,
+    <M as Mmcs<Challenge>>::Proof: Send,
+    <M as Mmcs<Challenge>>::ProverData<DenseMatrix<Challenge>>: Sync,
     Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<M::Commitment>,
     G: FriGenericConfig<Challenge>,
 {
@@ -40,16 +42,32 @@ where
     let pow_witness = challenger.grind(config.proof_of_work_bits);
 
     let query_proofs = info_span!("query phase").in_scope(|| {
-        iter::repeat_with(|| challenger.sample_bits(log_max_height + g.extra_query_index_bits()))
-            .take(config.num_queries)
-            .map(|index| QueryProof {
-                input_proof: open_input(index),
-                commit_phase_openings: answer_query(
-                    config,
-                    &commit_phase_result.data,
-                    index >> g.extra_query_index_bits(),
-                ),
-            })
+        // LITA: undo https://github.com/Plonky3/Plonky3/pull/333/commits/a202042a0d7f102830f548751555560e48677148#diff-28b0919b8d62afd4eb098b9d57ad393727c0dd95138fab75b1bef5244eb45e71R42
+        let query_indices: Vec<usize> = (0..config.num_queries)
+            .map(|_| challenger.sample_bits(log_max_height + g.extra_query_index_bits()))
+            .collect();
+
+        // LITA: to avoid requiring Dft: Sync, we compute `open_input` separately from `answer_query`
+        // The Radix2DIT DFT memoizes twiddle factors and that state makes it non-trivial to call in parallel.
+        let input_proofs: Vec<_> = query_indices
+            .iter()
+            .map(|index| open_input(*index))
+            .collect();
+
+        let extra_bits = g.extra_query_index_bits();
+
+        let commit_phase_openings: Vec<_> = query_indices
+            .into_par_iter()
+            .map(|index| answer_query(
+                config,
+                &commit_phase_result.data,
+                index >> extra_bits,
+            ))
+            .collect();
+
+        // LITA TODO: Support rayon multizip with a shim for non-parallel
+        izip!(input_proofs, commit_phase_openings)
+            .map(|(input_proof, commit_phase_openings)| QueryProof {input_proof, commit_phase_openings})
             .collect()
     });
 

--- a/interpolation/src/lib.rs
+++ b/interpolation/src/lib.rs
@@ -55,6 +55,10 @@ where
         .map(|(sg, diff_inv)| diff_inv * sg)
         .collect();
 
+    // LITA: our parallelism optimization here has been superceded
+    // by upstream columnwise_dot_product, which also has 2 levels of parallelism.
+    // See: https://github.com/lita-xyz/Plonky3/commit/1282cc19aa0f8b1e1974f58e7a6de2a8034f3a53#diff-c8307398fd810a26e0cd2e333f21f417ebe586aa9581e77ccf68660b60498022L48
+    // vs: https://github.com/Plonky3/Plonky3/pull/300/files#diff-24cbd5dc216765df386bbe3f0dd744c5d427e1444a6527d5fbd11d51eb2f3cc3R137
     let sum = coset_evals.columnwise_dot_product(&col_scale);
 
     let zerofier = two_adic_coset_zerofier::<EF>(log_height, EF::from_base(shift), point);

--- a/keccak-air/examples/prove_baby_bear_keccak.rs
+++ b/keccak-air/examples/prove_baby_bear_keccak.rs
@@ -8,7 +8,7 @@ use p3_field::extension::BinomialExtensionField;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
-use p3_matrix::Matrix;
+// use p3_matrix::Matrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 //use p3_monty_31::dft::RecursiveDft;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};

--- a/keccak-air/examples/prove_baby_bear_keccak.rs
+++ b/keccak-air/examples/prove_baby_bear_keccak.rs
@@ -3,13 +3,14 @@ use std::fmt::Debug;
 use p3_baby_bear::BabyBear;
 use p3_challenger::{HashChallenger, SerializingChallenger32};
 use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_fri::{FriConfig, TwoAdicFriPcs};
 use p3_keccak::Keccak256Hash;
 use p3_keccak_air::{generate_trace_rows, KeccakAir};
 use p3_matrix::Matrix;
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_monty_31::dft::RecursiveDft;
+//use p3_monty_31::dft::RecursiveDft;
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher32};
 use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::random;
@@ -59,8 +60,11 @@ fn main() -> Result<(), impl Debug> {
         proof_of_work_bits: 16,
         mmcs: challenge_mmcs,
     };
-    type Dft = RecursiveDft<Val>;
-    let dft = Dft::new(trace.height() << fri_config.log_blowup);
+    // LITA: Radix2DitParallel is faster and what we always used.
+    // type Dft = RecursiveDft<Val>;
+    type Dft = Radix2DitParallel<Val>;
+    // let dft = Dft::new(trace.height() << fri_config.log_blowup);
+    let dft = Dft::default();
 
     type Pcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
     let pcs = Pcs::new(dft, val_mmcs, fri_config);


### PR DESCRIPTION
- https://github.com/lita-xyz/Plonky3/commit/bdd338d61b3c1f24f17abd3b2848f1c910c49428,
- https://github.com/lita-xyz/Plonky3/commit/3c89583157f5186148674543c91160be0a734c8e,
- https://github.com/lita-xyz/Plonky3/commit/f1569fc4a67a7a6a775e0ebdf3e2d4118ca73115

on top of our `main-valida` branch based on upstream https://github.com/Plonky3/Plonky3/commit/ffa98d8. (The commit right after changes again benchmark size which would have been annoying to fix performance regressions).

For review/comparison convenience the branch [squashed-morgan-parallelism](https://github.com/lita-xyz/Plonky3/tree/squashed-morgan-parallelism) contains all commits and merged PR from upstream in a squashed manner as the original commits are not gathered in a convenient pull request: https://github.com/lita-xyz/Plonky3/commit/1282cc19aa0f8b1e1974f58e7a6de2a8034f3a53.

Comments were left where:
- original PR unparallelized routines
- parallelized routines, that aren't trivial to parallelize anymore due to additional Sync/Send limitations, notably on DFT algorithm.