### PR TITLE
check lengths of vectors opening points and vectors of matrices agree

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -168,7 +168,7 @@ pub struct FilteredAirBuilder<'a, AB: AirBuilder> {
     condition: AB::Expr,
 }
 
-impl<'a, AB: AirBuilder> AirBuilder for FilteredAirBuilder<'a, AB> {
+impl<AB: AirBuilder> AirBuilder for FilteredAirBuilder<'_, AB> {
     type F = AB::F;
     type Expr = AB::Expr;
     type Var = AB::Var;
@@ -195,7 +195,7 @@ impl<'a, AB: AirBuilder> AirBuilder for FilteredAirBuilder<'a, AB> {
     }
 }
 
-impl<'a, AB: ExtensionBuilder> ExtensionBuilder for FilteredAirBuilder<'a, AB> {
+impl<AB: ExtensionBuilder> ExtensionBuilder for FilteredAirBuilder<'_, AB> {
     type EF = AB::EF;
     type VarEF = AB::VarEF;
     type ExprEF = AB::ExprEF;
@@ -209,7 +209,7 @@ impl<'a, AB: ExtensionBuilder> ExtensionBuilder for FilteredAirBuilder<'a, AB> {
     }
 }
 
-impl<'a, AB: PermutationAirBuilder> PermutationAirBuilder for FilteredAirBuilder<'a, AB> {
+impl<AB: PermutationAirBuilder> PermutationAirBuilder for FilteredAirBuilder<'_, AB> {
     type MP = AB::MP;
 
     fn permutation(&self) -> Self::MP {

--- a/air/src/two_row_matrix.rs
+++ b/air/src/two_row_matrix.rs
@@ -15,7 +15,7 @@ impl<'a, T> TwoRowMatrixView<'a, T> {
     }
 }
 
-impl<'a, T> Matrix<T> for TwoRowMatrixView<'a, T> {
+impl<T> Matrix<T> for TwoRowMatrixView<'_, T> {
     fn width(&self) -> usize {
         self.local.len()
     }

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -58,7 +58,7 @@ pub trait FieldChallenger<F: Field>:
     }
 }
 
-impl<'a, C, T> CanObserve<T> for &'a mut C
+impl<C, T> CanObserve<T> for &mut C
 where
     C: CanObserve<T>,
 {
@@ -76,7 +76,7 @@ where
     }
 }
 
-impl<'a, C, T> CanSample<T> for &'a mut C
+impl<C, T> CanSample<T> for &mut C
 where
     C: CanSample<T>,
 {
@@ -96,7 +96,7 @@ where
     }
 }
 
-impl<'a, C, T> CanSampleBits<T> for &'a mut C
+impl<C, T> CanSampleBits<T> for &mut C
 where
     C: CanSampleBits<T>,
 {
@@ -106,7 +106,7 @@ where
     }
 }
 
-impl<'a, C, F: Field> FieldChallenger<F> for &'a mut C
+impl<C, F: Field> FieldChallenger<F> for &mut C
 where
     C: FieldChallenger<F>,
 {

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -288,6 +288,7 @@ where
             .par_iter()
             .map(|(data, points)| {
                 let mats = self.mmcs.get_matrices(data);
+                debug_assert_eq!(mats.len(), points.len());
                 izip!(mats, (*points).clone())
                     .collect::<Vec<_>>()
                     .par_iter()

--- a/uni-stark/src/check_constraints.rs
+++ b/uni-stark/src/check_constraints.rs
@@ -103,7 +103,7 @@ where
     }
 }
 
-impl<'a, F: Field> AirBuilderWithPublicValues for DebugConstraintBuilder<'a, F> {
+impl<F: Field> AirBuilderWithPublicValues for DebugConstraintBuilder<'_, F> {
     fn public_values(&self) -> Self::M {
         self.public_values
     }

--- a/uni-stark/src/folder.rs
+++ b/uni-stark/src/folder.rs
@@ -56,7 +56,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for ProverConstraintFolder<'a, SC> {
     }
 }
 
-impl<'a, SC: StarkGenericConfig> AirBuilderWithPublicValues for ProverConstraintFolder<'a, SC> {
+impl<SC: StarkGenericConfig> AirBuilderWithPublicValues for ProverConstraintFolder<'_, SC> {
     fn public_values(&self) -> Self::M {
         self.public_values
     }
@@ -94,7 +94,7 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for VerifierConstraintFolder<'a, SC>
         self.accumulator += x;
     }
 }
-impl<'a, SC: StarkGenericConfig> AirBuilderWithPublicValues for VerifierConstraintFolder<'a, SC> {
+impl<SC: StarkGenericConfig> AirBuilderWithPublicValues for VerifierConstraintFolder<'_, SC> {
     fn public_values(&self) -> Self::M {
         self.public_values
     }

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -17,7 +17,6 @@ use p3_uni_stark::{prove, verify, PublicRow, StarkConfig};
 use rand::thread_rng;
 
 /// For testing the public values feature
-
 pub struct FibonacciAir {}
 
 impl<F> BaseAir<F> for FibonacciAir {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -12,7 +12,7 @@ pub mod linear_map;
 /// Computes `ceil(a / b)`. Assumes `a + b` does not overflow.
 #[must_use]
 pub const fn ceil_div_usize(a: usize, b: usize) -> usize {
-    (a + b - 1) / b
+    a.div_ceil(b)
 }
 
 /// Computes `ceil(log_2(n))`.


### PR DESCRIPTION
See [valida-toolchain#874](https://github.com/lita-xyz/valida-toolchain/pull/874) for a discussion of how skipping this check can lead to hard-to-diagnose verification errors.