### PR TITLE
Remove `criterion` from devs to dev-deps

### DIFF
--- a/mersenne-31/Cargo.toml
+++ b/mersenne-31/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-criterion = "0.5"
 itertools = "0.12.0"
 p3-dft = { path = "../dft" }
 p3-field = { path = "../field" }
@@ -16,6 +15,7 @@ rand = "0.8.5"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
+criterion = "0.5"
 p3-field-testing = { path = "../field-testing" }
 rand_chacha = "0.3.1"
 


### PR DESCRIPTION
In order to build prover and verifier for WASM the `criterion` dependency needs to be moved from `dependencies` to `dev-dependencies`. Dependencies of `criterion` won't build for WASM. `criterion` should be in `dev-dependencies` since it's only a test / benchmarking dependency.